### PR TITLE
fix: Claude Agent SDK remediation for analyzer findings

### DIFF
--- a/autocare/user-auth-service/src/main/java/com/autocare/auth/models/User.java
+++ b/autocare/user-auth-service/src/main/java/com/autocare/auth/models/User.java
@@ -1,5 +1,6 @@
 package com.autocare.auth.models;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -60,6 +61,6 @@ public class User {
     public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }
 
-    public Set<Role> getRoles() { return roles; }
-    public void setRoles(Set<Role> roles) { this.roles = roles; }
+    public Set<Role> getRoles() { return Collections.unmodifiableSet(roles); }
+    public void setRoles(Set<Role> roles) { this.roles = roles != null ? new HashSet<>(roles) : new HashSet<>(); }
 }

--- a/autocare/user-auth-service/src/main/java/com/autocare/auth/payload/response/JwtResponse.java
+++ b/autocare/user-auth-service/src/main/java/com/autocare/auth/payload/response/JwtResponse.java
@@ -18,7 +18,7 @@ public class JwtResponse {
         this.id = id;
         this.username = username;
         this.email = email;
-        this.roles = roles;
+        this.roles = roles != null ? new ArrayList<>(roles) : new ArrayList<>();
     }
 
     public String getAccessToken() { return token; }

--- a/autocare/user-auth-service/src/main/java/com/autocare/auth/security/services/UserDetailsImpl.java
+++ b/autocare/user-auth-service/src/main/java/com/autocare/auth/security/services/UserDetailsImpl.java
@@ -1,6 +1,8 @@
 package com.autocare.auth.security.services;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -31,7 +33,9 @@ public class UserDetailsImpl implements UserDetails {
         this.username = username;
         this.email = email;
         this.password = password;
-        this.authorities = authorities;
+        this.authorities = authorities != null
+                ? Collections.unmodifiableList(new ArrayList<>(authorities))
+                : Collections.emptyList();
     }
 
     public static UserDetailsImpl build(User user) {

--- a/autocare/user-auth-service/src/test/java/com/autocare/auth/models/UserTest.java
+++ b/autocare/user-auth-service/src/test/java/com/autocare/auth/models/UserTest.java
@@ -1,0 +1,190 @@
+package com.autocare.auth.models;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UserTest {
+
+    private User user;
+
+    @BeforeEach
+    public void setUp() {
+        user = new User("testuser", "test@example.com", "password123");
+    }
+
+    @Test
+    public void testDefaultConstructor() {
+        User emptyUser = new User();
+        assertNull(emptyUser.getId());
+        assertNull(emptyUser.getUsername());
+        assertNull(emptyUser.getEmail());
+        assertNull(emptyUser.getPassword());
+        assertNotNull(emptyUser.getRoles());
+        assertTrue(emptyUser.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testParameterizedConstructor() {
+        assertEquals("testuser", user.getUsername());
+        assertEquals("test@example.com", user.getEmail());
+        assertEquals("password123", user.getPassword());
+        assertNull(user.getId());
+        assertNotNull(user.getRoles());
+        assertTrue(user.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testSetAndGetId() {
+        user.setId(42L);
+        assertEquals(42L, user.getId());
+    }
+
+    @Test
+    public void testSetAndGetUsername() {
+        user.setUsername("newuser");
+        assertEquals("newuser", user.getUsername());
+    }
+
+    @Test
+    public void testSetAndGetEmail() {
+        user.setEmail("new@example.com");
+        assertEquals("new@example.com", user.getEmail());
+    }
+
+    @Test
+    public void testSetAndGetPassword() {
+        user.setPassword("newpassword");
+        assertEquals("newpassword", user.getPassword());
+    }
+
+    // EI_EXPOSE_REP: getRoles() should return an unmodifiable set
+    @Test
+    public void testGetRolesReturnsUnmodifiableSet() {
+        Role role = new Role();
+        role.setName(ERole.ROLE_USER);
+        Set<Role> roles = new HashSet<>();
+        roles.add(role);
+        user.setRoles(roles);
+
+        Set<Role> returnedRoles = user.getRoles();
+        assertThrows(UnsupportedOperationException.class, () -> returnedRoles.add(new Role()));
+    }
+
+    // EI_EXPOSE_REP: modifying the returned set should not affect internal state
+    @Test
+    public void testGetRolesDoesNotExposeInternalRepresentation() {
+        Role role = new Role();
+        role.setName(ERole.ROLE_USER);
+        Set<Role> roles = new HashSet<>();
+        roles.add(role);
+        user.setRoles(roles);
+
+        Set<Role> returnedRoles = user.getRoles();
+        assertEquals(1, returnedRoles.size());
+
+        // Attempt to modify should throw exception, not affect internal state
+        assertThrows(UnsupportedOperationException.class, () -> returnedRoles.remove(role));
+        assertEquals(1, user.getRoles().size());
+    }
+
+    // EI_EXPOSE_REP2: setRoles() should make a defensive copy
+    @Test
+    public void testSetRolesMakesDefensiveCopy() {
+        Role role1 = new Role();
+        role1.setName(ERole.ROLE_USER);
+        Set<Role> roles = new HashSet<>();
+        roles.add(role1);
+
+        user.setRoles(roles);
+
+        // Modify the original set after setting
+        Role role2 = new Role();
+        role2.setName(ERole.ROLE_ADMIN);
+        roles.add(role2);
+
+        // Internal set should not be affected by external modification
+        assertEquals(1, user.getRoles().size());
+    }
+
+    // EI_EXPOSE_REP2: setRoles() with null should result in empty set
+    @Test
+    public void testSetRolesWithNull() {
+        user.setRoles(null);
+        assertNotNull(user.getRoles());
+        assertTrue(user.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testSetRolesWithEmptySet() {
+        user.setRoles(new HashSet<>());
+        assertNotNull(user.getRoles());
+        assertTrue(user.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testSetRolesWithMultipleRoles() {
+        Role roleUser = new Role();
+        roleUser.setName(ERole.ROLE_USER);
+
+        Role roleAdmin = new Role();
+        roleAdmin.setName(ERole.ROLE_ADMIN);
+
+        Set<Role> roles = new HashSet<>();
+        roles.add(roleUser);
+        roles.add(roleAdmin);
+
+        user.setRoles(roles);
+        assertEquals(2, user.getRoles().size());
+    }
+
+    @Test
+    public void testGetRolesReturnsCopyNotSameReference() {
+        Role role = new Role();
+        role.setName(ERole.ROLE_USER);
+        Set<Role> roles = new HashSet<>();
+        roles.add(role);
+        user.setRoles(roles);
+
+        Set<Role> firstCall = user.getRoles();
+        Set<Role> secondCall = user.getRoles();
+
+        // Both calls should return equal sets
+        assertEquals(firstCall, secondCall);
+    }
+
+    @Test
+    public void testInitialRolesIsEmptySet() {
+        User newUser = new User("user", "user@test.com", "pass");
+        assertNotNull(newUser.getRoles());
+        assertTrue(newUser.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testSetRolesDoesNotAllowExternalMutationAfterSet() {
+        Set<Role> externalRoles = new HashSet<>();
+        Role role = new Role();
+        role.setName(ERole.ROLE_USER);
+        externalRoles.add(role);
+
+        user.setRoles(externalRoles);
+        assertEquals(1, user.getRoles().size());
+
+        // Mutate external set
+        externalRoles.clear();
+
+        // User's internal roles should remain unchanged
+        assertEquals(1, user.getRoles().size());
+    }
+
+    @Test
+    public void testGetRolesIsUnmodifiableAfterSetWithNull() {
+        user.setRoles(null);
+        Set<Role> roles = user.getRoles();
+        assertThrows(UnsupportedOperationException.class, () -> roles.add(new Role()));
+    }
+}

--- a/autocare/user-auth-service/src/test/java/com/autocare/auth/payload/response/JwtResponseTest.java
+++ b/autocare/user-auth-service/src/test/java/com/autocare/auth/payload/response/JwtResponseTest.java
@@ -1,0 +1,169 @@
+package com.autocare.auth.payload.response;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JwtResponseTest {
+
+    @Test
+    public void testConstructorWithValidRoles() {
+        List<String> roles = Arrays.asList("ROLE_USER", "ROLE_ADMIN");
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", roles);
+
+        assertEquals("token123", response.getAccessToken());
+        assertEquals(1L, response.getId());
+        assertEquals("testuser", response.getUsername());
+        assertEquals("test@example.com", response.getEmail());
+        assertEquals("Bearer", response.getTokenType());
+        assertNotNull(response.getRoles());
+        assertEquals(2, response.getRoles().size());
+        assertTrue(response.getRoles().contains("ROLE_USER"));
+        assertTrue(response.getRoles().contains("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void testConstructorWithNullRoles() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+
+        assertNotNull(response.getRoles());
+        assertTrue(response.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testRolesDefensiveCopyOnConstruction() {
+        List<String> originalRoles = new ArrayList<>(Arrays.asList("ROLE_USER"));
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", originalRoles);
+
+        // Mutate the original list after construction
+        originalRoles.add("ROLE_ADMIN");
+
+        // The internal list should not be affected
+        assertEquals(1, response.getRoles().size());
+        assertFalse(response.getRoles().contains("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void testGetRolesReturnsDefensiveCopy() {
+        List<String> roles = new ArrayList<>(Arrays.asList("ROLE_USER"));
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", roles);
+
+        // Mutate the returned list
+        List<String> returnedRoles = response.getRoles();
+        returnedRoles.add("ROLE_ADMIN");
+
+        // The internal list should not be affected
+        assertEquals(1, response.getRoles().size());
+        assertFalse(response.getRoles().contains("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void testGetRolesReturnsDifferentInstance() {
+        List<String> roles = Arrays.asList("ROLE_USER");
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", roles);
+
+        List<String> firstCall = response.getRoles();
+        List<String> secondCall = response.getRoles();
+
+        assertNotSame(firstCall, secondCall);
+        assertEquals(firstCall, secondCall);
+    }
+
+    @Test
+    public void testSetAccessToken() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+        response.setAccessToken("newToken456");
+        assertEquals("newToken456", response.getAccessToken());
+    }
+
+    @Test
+    public void testSetTokenType() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+        response.setTokenType("Basic");
+        assertEquals("Basic", response.getTokenType());
+    }
+
+    @Test
+    public void testSetId() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+        response.setId(99L);
+        assertEquals(99L, response.getId());
+    }
+
+    @Test
+    public void testSetEmail() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+        response.setEmail("newemail@example.com");
+        assertEquals("newemail@example.com", response.getEmail());
+    }
+
+    @Test
+    public void testSetUsername() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+        response.setUsername("newuser");
+        assertEquals("newuser", response.getUsername());
+    }
+
+    @Test
+    public void testDefaultTokenType() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+        assertEquals("Bearer", response.getTokenType());
+    }
+
+    @Test
+    public void testConstructorWithEmptyRoles() {
+        List<String> emptyRoles = new ArrayList<>();
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", emptyRoles);
+
+        assertNotNull(response.getRoles());
+        assertTrue(response.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testConstructorWithNullToken() {
+        JwtResponse response = new JwtResponse(null, 1L, "testuser", "test@example.com", null);
+        assertNull(response.getAccessToken());
+    }
+
+    @Test
+    public void testConstructorWithNullId() {
+        JwtResponse response = new JwtResponse("token123", null, "testuser", "test@example.com", null);
+        assertNull(response.getId());
+    }
+
+    @Test
+    public void testConstructorWithNullUsername() {
+        JwtResponse response = new JwtResponse("token123", 1L, null, "test@example.com", null);
+        assertNull(response.getUsername());
+    }
+
+    @Test
+    public void testConstructorWithNullEmail() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", null, null);
+        assertNull(response.getEmail());
+    }
+
+    @Test
+    public void testRolesListIsNotSameAsInput() {
+        List<String> roles = new ArrayList<>(Arrays.asList("ROLE_USER"));
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", roles);
+
+        assertNotSame(roles, response.getRoles());
+    }
+
+    @Test
+    public void testMultipleRolesPreserved() {
+        List<String> roles = Arrays.asList("ROLE_USER", "ROLE_ADMIN", "ROLE_MODERATOR");
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", roles);
+
+        List<String> returnedRoles = response.getRoles();
+        assertEquals(3, returnedRoles.size());
+        assertTrue(returnedRoles.contains("ROLE_USER"));
+        assertTrue(returnedRoles.contains("ROLE_ADMIN"));
+        assertTrue(returnedRoles.contains("ROLE_MODERATOR"));
+    }
+}

--- a/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/LaborLine.java
+++ b/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/LaborLine.java
@@ -29,7 +29,11 @@ public class LaborLine {
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
+    // EI_EXPOSE_REP/EI_EXPOSE_REP2: WorkOrder is a JPA-managed entity reference;
+    // defensive copying would break proxy identity, lazy-loading, and dirty-tracking.
+    @SuppressWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     public WorkOrder getWorkOrder() { return workOrder; }
+    @SuppressWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     public void setWorkOrder(WorkOrder workOrder) { this.workOrder = workOrder; }
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }

--- a/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/PartLine.java
+++ b/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/PartLine.java
@@ -30,7 +30,11 @@ public class PartLine {
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
+    // EI_EXPOSE_REP/EI_EXPOSE_REP2: WorkOrder is a JPA-managed entity reference;
+    // defensive copying would break proxy identity, lazy-loading, and dirty-tracking.
+    @SuppressWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     public WorkOrder getWorkOrder() { return workOrder; }
+    @SuppressWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     public void setWorkOrder(WorkOrder workOrder) { this.workOrder = workOrder; }
     public String getPartName() { return partName; }
     public void setPartName(String partName) { this.partName = partName; }

--- a/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/ServiceSchedule.java
+++ b/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/ServiceSchedule.java
@@ -30,9 +30,15 @@ public class ServiceSchedule {
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
+    // EI_EXPOSE_REP/EI_EXPOSE_REP2: Vehicle and Bay are JPA-managed entity references;
+    // defensive copying would break proxy identity, lazy-loading, and dirty-tracking.
+    @SuppressWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     public Vehicle getVehicle() { return vehicle; }
+    @SuppressWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     public void setVehicle(Vehicle vehicle) { this.vehicle = vehicle; }
+    @SuppressWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     public Bay getBay() { return bay; }
+    @SuppressWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     public void setBay(Bay bay) { this.bay = bay; }
     public LocalDateTime getScheduledAt() { return scheduledAt; }
     public void setScheduledAt(LocalDateTime scheduledAt) { this.scheduledAt = scheduledAt; }

--- a/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/WorkOrder.java
+++ b/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/WorkOrder.java
@@ -3,6 +3,7 @@ package com.autocare.maintenance.model;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -64,10 +65,10 @@ public class WorkOrder {
     public void setDescription(String description) { this.description = description; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
-    public Set<PartLine> getPartLines() { return partLines; }
+    public Set<PartLine> getPartLines() { return Collections.unmodifiableSet(partLines); }
     public void setPartLines(Set<PartLine> partLines) { this.partLines = partLines; }
-    public Set<LaborLine> getLaborLines() { return laborLines; }
+    public Set<LaborLine> getLaborLines() { return Collections.unmodifiableSet(laborLines); }
     public void setLaborLines(Set<LaborLine> laborLines) { this.laborLines = laborLines; }
-    public Set<WorkOrderStatusHistory> getStatusHistory() { return statusHistory; }
+    public Set<WorkOrderStatusHistory> getStatusHistory() { return Collections.unmodifiableSet(statusHistory); }
     public void setStatusHistory(Set<WorkOrderStatusHistory> statusHistory) { this.statusHistory = statusHistory; }
 }

--- a/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/security/services/JwtUserDetails.java
+++ b/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/security/services/JwtUserDetails.java
@@ -3,7 +3,9 @@ package com.autocare.maintenance.security.services;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class JwtUserDetails implements UserDetails {
@@ -13,12 +15,12 @@ public class JwtUserDetails implements UserDetails {
 
     public JwtUserDetails(String username, List<GrantedAuthority> authorities) {
         this.username = username;
-        this.authorities = authorities;
+        this.authorities = authorities != null ? new ArrayList<>(authorities) : new ArrayList<>();
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return authorities;
+        return Collections.unmodifiableList(authorities);
     }
 
     @Override

--- a/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/LaborLineTest.java
+++ b/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/LaborLineTest.java
@@ -1,0 +1,191 @@
+package com.autocare.maintenance.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LaborLineTest {
+
+    private LaborLine laborLine;
+
+    @BeforeEach
+    void setUp() {
+        laborLine = new LaborLine();
+    }
+
+    @Test
+    void testSetAndGetId() {
+        laborLine.setId(42L);
+        assertEquals(42L, laborLine.getId());
+    }
+
+    @Test
+    void testSetAndGetDescription() {
+        laborLine.setDescription("Oil Change");
+        assertEquals("Oil Change", laborLine.getDescription());
+    }
+
+    @Test
+    void testSetAndGetHours() {
+        BigDecimal hours = new BigDecimal("2.50");
+        laborLine.setHours(hours);
+        assertEquals(new BigDecimal("2.50"), laborLine.getHours());
+    }
+
+    @Test
+    void testSetAndGetRate() {
+        BigDecimal rate = new BigDecimal("75.00");
+        laborLine.setRate(rate);
+        assertEquals(new BigDecimal("75.00"), laborLine.getRate());
+    }
+
+    @Test
+    void testSetAndGetWorkOrder() {
+        WorkOrder workOrder = new WorkOrder();
+        laborLine.setWorkOrder(workOrder);
+        assertSame(workOrder, laborLine.getWorkOrder(),
+                "getWorkOrder should return the same JPA-managed entity reference (no defensive copy)");
+    }
+
+    @Test
+    void testWorkOrderReferenceIdentity() {
+        WorkOrder workOrder = new WorkOrder();
+        laborLine.setWorkOrder(workOrder);
+        WorkOrder retrieved = laborLine.getWorkOrder();
+        // EI_EXPOSE_REP fix: for JPA entities, the same reference must be returned
+        // to preserve proxy identity and lazy-loading
+        assertSame(workOrder, retrieved,
+                "WorkOrder reference must be identical to support JPA proxy behavior");
+    }
+
+    @Test
+    void testSetWorkOrderPreservesReference() {
+        WorkOrder workOrder1 = new WorkOrder();
+        WorkOrder workOrder2 = new WorkOrder();
+
+        laborLine.setWorkOrder(workOrder1);
+        assertSame(workOrder1, laborLine.getWorkOrder());
+
+        laborLine.setWorkOrder(workOrder2);
+        assertSame(workOrder2, laborLine.getWorkOrder(),
+                "After updating workOrder, the new reference should be returned");
+    }
+
+    @Test
+    void testSetWorkOrderToNull() {
+        WorkOrder workOrder = new WorkOrder();
+        laborLine.setWorkOrder(workOrder);
+        laborLine.setWorkOrder(null);
+        assertNull(laborLine.getWorkOrder());
+    }
+
+    @Test
+    void testDefaultIdIsNull() {
+        assertNull(laborLine.getId());
+    }
+
+    @Test
+    void testDefaultDescriptionIsNull() {
+        assertNull(laborLine.getDescription());
+    }
+
+    @Test
+    void testDefaultHoursIsNull() {
+        assertNull(laborLine.getHours());
+    }
+
+    @Test
+    void testDefaultRateIsNull() {
+        assertNull(laborLine.getRate());
+    }
+
+    @Test
+    void testDefaultWorkOrderIsNull() {
+        assertNull(laborLine.getWorkOrder());
+    }
+
+    @Test
+    void testSetHoursWithMinimumValue() {
+        BigDecimal minHours = new BigDecimal("0.01");
+        laborLine.setHours(minHours);
+        assertEquals(new BigDecimal("0.01"), laborLine.getHours());
+    }
+
+    @Test
+    void testSetRateWithMinimumValue() {
+        BigDecimal minRate = new BigDecimal("0.01");
+        laborLine.setRate(minRate);
+        assertEquals(new BigDecimal("0.01"), laborLine.getRate());
+    }
+
+    @Test
+    void testSetHoursWithLargeValue() {
+        BigDecimal largeHours = new BigDecimal("9999.99");
+        laborLine.setHours(largeHours);
+        assertEquals(new BigDecimal("9999.99"), laborLine.getHours());
+    }
+
+    @Test
+    void testSetRateWithLargeValue() {
+        BigDecimal largeRate = new BigDecimal("99999999.99");
+        laborLine.setRate(largeRate);
+        assertEquals(new BigDecimal("99999999.99"), laborLine.getRate());
+    }
+
+    @Test
+    void testSetDescriptionWithEmptyString() {
+        laborLine.setDescription("");
+        assertEquals("", laborLine.getDescription());
+    }
+
+    @Test
+    void testSetDescriptionWithLongString() {
+        String longDescription = "A".repeat(500);
+        laborLine.setDescription(longDescription);
+        assertEquals(longDescription, laborLine.getDescription());
+    }
+
+    @Test
+    void testMultipleFieldsSetTogether() {
+        WorkOrder workOrder = new WorkOrder();
+        laborLine.setId(1L);
+        laborLine.setWorkOrder(workOrder);
+        laborLine.setDescription("Brake Inspection");
+        laborLine.setHours(new BigDecimal("1.50"));
+        laborLine.setRate(new BigDecimal("85.00"));
+
+        assertEquals(1L, laborLine.getId());
+        assertSame(workOrder, laborLine.getWorkOrder());
+        assertEquals("Brake Inspection", laborLine.getDescription());
+        assertEquals(new BigDecimal("1.50"), laborLine.getHours());
+        assertEquals(new BigDecimal("85.00"), laborLine.getRate());
+    }
+
+    @Test
+    void testGetWorkOrderDoesNotReturnDefensiveCopy() {
+        WorkOrder workOrder = new WorkOrder();
+        laborLine.setWorkOrder(workOrder);
+
+        WorkOrder first = laborLine.getWorkOrder();
+        WorkOrder second = laborLine.getWorkOrder();
+
+        // Both calls should return the same reference (JPA proxy compatibility)
+        assertSame(first, second,
+                "Repeated calls to getWorkOrder should return the same reference");
+        assertSame(workOrder, first,
+                "getWorkOrder must return the original reference, not a copy");
+    }
+
+    @Test
+    void testSetWorkOrderDoesNotMakeDefensiveCopy() {
+        WorkOrder workOrder = new WorkOrder();
+        laborLine.setWorkOrder(workOrder);
+
+        // The stored reference should be the exact same object passed in
+        assertSame(workOrder, laborLine.getWorkOrder(),
+                "setWorkOrder must store the original reference, not a defensive copy");
+    }
+}

--- a/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/PartLineTest.java
+++ b/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/PartLineTest.java
@@ -1,0 +1,198 @@
+package com.autocare.maintenance.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PartLineTest {
+
+    private PartLine partLine;
+
+    @BeforeEach
+    void setUp() {
+        partLine = new PartLine();
+    }
+
+    // -------------------------------------------------------------------------
+    // id
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testSetAndGetId() {
+        partLine.setId(42L);
+        assertEquals(42L, partLine.getId());
+    }
+
+    @Test
+    void testIdDefaultsToNull() {
+        assertNull(partLine.getId());
+    }
+
+    // -------------------------------------------------------------------------
+    // workOrder – EI_EXPOSE_REP / EI_EXPOSE_REP2 remediation tests
+    // The getter and setter must return/accept the exact same reference so that
+    // JPA proxy identity, lazy-loading, and dirty-tracking are preserved.
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testSetAndGetWorkOrder_sameReference() {
+        WorkOrder workOrder = new WorkOrder();
+        partLine.setWorkOrder(workOrder);
+
+        // EI_EXPOSE_REP2 fix: setter must store the reference as-is (no defensive copy)
+        // EI_EXPOSE_REP  fix: getter must return the stored reference as-is
+        assertSame(workOrder, partLine.getWorkOrder(),
+                "getWorkOrder() must return the exact same reference that was set " +
+                "(defensive copying would break JPA proxy identity)");
+    }
+
+    @Test
+    void testSetWorkOrder_nullAllowed() {
+        partLine.setWorkOrder(null);
+        assertNull(partLine.getWorkOrder());
+    }
+
+    @Test
+    void testSetWorkOrder_replacesExistingReference() {
+        WorkOrder first  = new WorkOrder();
+        WorkOrder second = new WorkOrder();
+
+        partLine.setWorkOrder(first);
+        partLine.setWorkOrder(second);
+
+        assertSame(second, partLine.getWorkOrder(),
+                "setWorkOrder() must replace the stored reference with the new one");
+        assertNotSame(first, partLine.getWorkOrder());
+    }
+
+    @Test
+    void testGetWorkOrder_mutatingExternalReferenceIsReflected() {
+        // Because no defensive copy is made, mutations to the original object
+        // must be visible through the getter (JPA dirty-tracking requirement).
+        WorkOrder workOrder = new WorkOrder();
+        partLine.setWorkOrder(workOrder);
+
+        // mutate the original object
+        workOrder.setId(99L);
+
+        assertSame(workOrder, partLine.getWorkOrder());
+        assertEquals(99L, partLine.getWorkOrder().getId());
+    }
+
+    // -------------------------------------------------------------------------
+    // partName
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testSetAndGetPartName() {
+        partLine.setPartName("Oil Filter");
+        assertEquals("Oil Filter", partLine.getPartName());
+    }
+
+    @Test
+    void testPartNameDefaultsToNull() {
+        assertNull(partLine.getPartName());
+    }
+
+    @Test
+    void testSetPartName_emptyString() {
+        partLine.setPartName("");
+        assertEquals("", partLine.getPartName());
+    }
+
+    @Test
+    void testSetPartName_overwritesPreviousValue() {
+        partLine.setPartName("Brake Pad");
+        partLine.setPartName("Air Filter");
+        assertEquals("Air Filter", partLine.getPartName());
+    }
+
+    // -------------------------------------------------------------------------
+    // quantity
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testSetAndGetQuantity() {
+        partLine.setQuantity(5);
+        assertEquals(5, partLine.getQuantity());
+    }
+
+    @Test
+    void testQuantityDefaultsToNull() {
+        assertNull(partLine.getQuantity());
+    }
+
+    @Test
+    void testSetQuantity_minimumValidValue() {
+        partLine.setQuantity(1);
+        assertEquals(1, partLine.getQuantity());
+    }
+
+    @Test
+    void testSetQuantity_largeValue() {
+        partLine.setQuantity(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, partLine.getQuantity());
+    }
+
+    // -------------------------------------------------------------------------
+    // unitCost
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testSetAndGetUnitCost() {
+        BigDecimal cost = new BigDecimal("19.99");
+        partLine.setUnitCost(cost);
+        assertEquals(new BigDecimal("19.99"), partLine.getUnitCost());
+    }
+
+    @Test
+    void testUnitCostDefaultsToNull() {
+        assertNull(partLine.getUnitCost());
+    }
+
+    @Test
+    void testSetUnitCost_minimumValidValue() {
+        BigDecimal minCost = new BigDecimal("0.01");
+        partLine.setUnitCost(minCost);
+        assertEquals(new BigDecimal("0.01"), partLine.getUnitCost());
+    }
+
+    @Test
+    void testSetUnitCost_largeValue() {
+        BigDecimal largeCost = new BigDecimal("9999999.99");
+        partLine.setUnitCost(largeCost);
+        assertEquals(new BigDecimal("9999999.99"), partLine.getUnitCost());
+    }
+
+    @Test
+    void testSetUnitCost_overwritesPreviousValue() {
+        partLine.setUnitCost(new BigDecimal("10.00"));
+        partLine.setUnitCost(new BigDecimal("25.50"));
+        assertEquals(new BigDecimal("25.50"), partLine.getUnitCost());
+    }
+
+    // -------------------------------------------------------------------------
+    // combined state
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testFullyPopulatedPartLine() {
+        WorkOrder workOrder = new WorkOrder();
+        workOrder.setId(1L);
+
+        partLine.setId(100L);
+        partLine.setWorkOrder(workOrder);
+        partLine.setPartName("Spark Plug");
+        partLine.setQuantity(4);
+        partLine.setUnitCost(new BigDecimal("3.75"));
+
+        assertEquals(100L, partLine.getId());
+        assertSame(workOrder, partLine.getWorkOrder());
+        assertEquals("Spark Plug", partLine.getPartName());
+        assertEquals(4, partLine.getQuantity());
+        assertEquals(new BigDecimal("3.75"), partLine.getUnitCost());
+    }
+}

--- a/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/ServiceScheduleTest.java
+++ b/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/ServiceScheduleTest.java
@@ -1,0 +1,223 @@
+package com.autocare.maintenance.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ServiceScheduleTest {
+
+    private ServiceSchedule serviceSchedule;
+
+    @BeforeEach
+    void setUp() {
+        serviceSchedule = new ServiceSchedule();
+    }
+
+    @Test
+    void testDefaultStatusIsConfirmed() {
+        assertEquals("CONFIRMED", serviceSchedule.getStatus());
+    }
+
+    @Test
+    void testSetAndGetId() {
+        serviceSchedule.setId(42L);
+        assertEquals(42L, serviceSchedule.getId());
+    }
+
+    @Test
+    void testSetAndGetIdNull() {
+        serviceSchedule.setId(null);
+        assertNull(serviceSchedule.getId());
+    }
+
+    @Test
+    void testSetAndGetVehicle() {
+        Vehicle vehicle = new Vehicle();
+        serviceSchedule.setVehicle(vehicle);
+        assertSame(vehicle, serviceSchedule.getVehicle());
+    }
+
+    @Test
+    void testSetVehicleNull() {
+        serviceSchedule.setVehicle(null);
+        assertNull(serviceSchedule.getVehicle());
+    }
+
+    @Test
+    void testGetVehicleReturnsSameReference() {
+        Vehicle vehicle = new Vehicle();
+        serviceSchedule.setVehicle(vehicle);
+        Vehicle retrieved = serviceSchedule.getVehicle();
+        assertSame(vehicle, retrieved,
+                "getVehicle() should return the same JPA-managed entity reference (no defensive copy)");
+    }
+
+    @Test
+    void testSetAndGetBay() {
+        Bay bay = new Bay();
+        serviceSchedule.setBay(bay);
+        assertSame(bay, serviceSchedule.getBay());
+    }
+
+    @Test
+    void testSetBayNull() {
+        serviceSchedule.setBay(null);
+        assertNull(serviceSchedule.getBay());
+    }
+
+    @Test
+    void testGetBayReturnsSameReference() {
+        Bay bay = new Bay();
+        serviceSchedule.setBay(bay);
+        Bay retrieved = serviceSchedule.getBay();
+        assertSame(bay, retrieved,
+                "getBay() should return the same JPA-managed entity reference (no defensive copy)");
+    }
+
+    @Test
+    void testSetAndGetScheduledAt() {
+        LocalDateTime now = LocalDateTime.now();
+        serviceSchedule.setScheduledAt(now);
+        assertEquals(now, serviceSchedule.getScheduledAt());
+    }
+
+    @Test
+    void testSetScheduledAtNull() {
+        serviceSchedule.setScheduledAt(null);
+        assertNull(serviceSchedule.getScheduledAt());
+    }
+
+    @Test
+    void testSetAndGetServiceType() {
+        serviceSchedule.setServiceType("OIL_CHANGE");
+        assertEquals("OIL_CHANGE", serviceSchedule.getServiceType());
+    }
+
+    @Test
+    void testSetServiceTypeNull() {
+        serviceSchedule.setServiceType(null);
+        assertNull(serviceSchedule.getServiceType());
+    }
+
+    @Test
+    void testSetAndGetStatus() {
+        serviceSchedule.setStatus("PENDING");
+        assertEquals("PENDING", serviceSchedule.getStatus());
+    }
+
+    @Test
+    void testSetStatusNull() {
+        serviceSchedule.setStatus(null);
+        assertNull(serviceSchedule.getStatus());
+    }
+
+    @Test
+    void testSetStatusOverridesDefault() {
+        assertEquals("CONFIRMED", serviceSchedule.getStatus());
+        serviceSchedule.setStatus("CANCELLED");
+        assertEquals("CANCELLED", serviceSchedule.getStatus());
+    }
+
+    @Test
+    void testVehicleReferenceIdentityPreservedAfterMutation() {
+        Vehicle vehicle = new Vehicle();
+        serviceSchedule.setVehicle(vehicle);
+        // Mutate the vehicle object externally
+        vehicle.setId(99L);
+        // The schedule should reflect the mutation since it holds the same reference
+        assertSame(vehicle, serviceSchedule.getVehicle());
+        assertEquals(99L, serviceSchedule.getVehicle().getId());
+    }
+
+    @Test
+    void testBayReferenceIdentityPreservedAfterMutation() {
+        Bay bay = new Bay();
+        serviceSchedule.setBay(bay);
+        // Mutate the bay object externally
+        bay.setId(55L);
+        // The schedule should reflect the mutation since it holds the same reference
+        assertSame(bay, serviceSchedule.getBay());
+        assertEquals(55L, serviceSchedule.getBay().getId());
+    }
+
+    @Test
+    void testSetVehicleReplacesExistingVehicle() {
+        Vehicle vehicle1 = new Vehicle();
+        vehicle1.setId(1L);
+        Vehicle vehicle2 = new Vehicle();
+        vehicle2.setId(2L);
+
+        serviceSchedule.setVehicle(vehicle1);
+        assertSame(vehicle1, serviceSchedule.getVehicle());
+
+        serviceSchedule.setVehicle(vehicle2);
+        assertSame(vehicle2, serviceSchedule.getVehicle());
+        assertNotSame(vehicle1, serviceSchedule.getVehicle());
+    }
+
+    @Test
+    void testSetBayReplacesExistingBay() {
+        Bay bay1 = new Bay();
+        bay1.setId(1L);
+        Bay bay2 = new Bay();
+        bay2.setId(2L);
+
+        serviceSchedule.setBay(bay1);
+        assertSame(bay1, serviceSchedule.getBay());
+
+        serviceSchedule.setBay(bay2);
+        assertSame(bay2, serviceSchedule.getBay());
+        assertNotSame(bay1, serviceSchedule.getBay());
+    }
+
+    @Test
+    void testFullScheduleSetup() {
+        LocalDateTime scheduledTime = LocalDateTime.of(2024, 6, 15, 10, 30);
+        Vehicle vehicle = new Vehicle();
+        vehicle.setId(10L);
+        Bay bay = new Bay();
+        bay.setId(5L);
+
+        serviceSchedule.setId(1L);
+        serviceSchedule.setVehicle(vehicle);
+        serviceSchedule.setBay(bay);
+        serviceSchedule.setScheduledAt(scheduledTime);
+        serviceSchedule.setServiceType("TIRE_ROTATION");
+        serviceSchedule.setStatus("CONFIRMED");
+
+        assertEquals(1L, serviceSchedule.getId());
+        assertSame(vehicle, serviceSchedule.getVehicle());
+        assertSame(bay, serviceSchedule.getBay());
+        assertEquals(scheduledTime, serviceSchedule.getScheduledAt());
+        assertEquals("TIRE_ROTATION", serviceSchedule.getServiceType());
+        assertEquals("CONFIRMED", serviceSchedule.getStatus());
+    }
+
+    @Test
+    void testNewInstanceHasNullId() {
+        assertNull(serviceSchedule.getId());
+    }
+
+    @Test
+    void testNewInstanceHasNullVehicle() {
+        assertNull(serviceSchedule.getVehicle());
+    }
+
+    @Test
+    void testNewInstanceHasNullBay() {
+        assertNull(serviceSchedule.getBay());
+    }
+
+    @Test
+    void testNewInstanceHasNullScheduledAt() {
+        assertNull(serviceSchedule.getScheduledAt());
+    }
+
+    @Test
+    void testNewInstanceHasNullServiceType() {
+        assertNull(serviceSchedule.getServiceType());
+    }
+}

--- a/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/security/services/JwtUserDetailsTest.java
+++ b/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/security/services/JwtUserDetailsTest.java
@@ -1,0 +1,197 @@
+package com.autocare.maintenance.security.services;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtUserDetailsTest {
+
+    @Test
+    void testConstructorWithValidUsernameAndAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        assertEquals("testuser", userDetails.getUsername());
+        assertEquals(1, userDetails.getAuthorities().size());
+    }
+
+    @Test
+    void testConstructorWithNullAuthoritiesCreatesEmptyList() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", null);
+
+        assertNotNull(userDetails.getAuthorities());
+        assertTrue(userDetails.getAuthorities().isEmpty());
+    }
+
+    @Test
+    void testConstructorDefensivelyCopiesAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        // Mutate the original list after construction
+        authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+
+        // Internal state should not be affected
+        assertEquals(1, userDetails.getAuthorities().size());
+    }
+
+    @Test
+    void testGetAuthoritiesReturnsUnmodifiableCollection() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        Collection<? extends GrantedAuthority> returnedAuthorities = userDetails.getAuthorities();
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            ((List<GrantedAuthority>) returnedAuthorities).add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        });
+    }
+
+    @Test
+    void testGetAuthoritiesCannotBeModifiedExternally() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        Collection<? extends GrantedAuthority> returnedAuthorities = userDetails.getAuthorities();
+
+        // Verify that the returned collection is unmodifiable
+        assertThrows(UnsupportedOperationException.class, () -> {
+            returnedAuthorities.clear();
+        });
+    }
+
+    @Test
+    void testGetPasswordReturnsNull() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", null);
+
+        assertNull(userDetails.getPassword());
+    }
+
+    @Test
+    void testGetUsernameReturnsCorrectValue() {
+        JwtUserDetails userDetails = new JwtUserDetails("myuser", null);
+
+        assertEquals("myuser", userDetails.getUsername());
+    }
+
+    @Test
+    void testIsAccountNonExpiredReturnsTrue() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", null);
+
+        assertTrue(userDetails.isAccountNonExpired());
+    }
+
+    @Test
+    void testIsAccountNonLockedReturnsTrue() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", null);
+
+        assertTrue(userDetails.isAccountNonLocked());
+    }
+
+    @Test
+    void testIsCredentialsNonExpiredReturnsTrue() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", null);
+
+        assertTrue(userDetails.isCredentialsNonExpired());
+    }
+
+    @Test
+    void testIsEnabledReturnsTrue() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", null);
+
+        assertTrue(userDetails.isEnabled());
+    }
+
+    @Test
+    void testConstructorWithMultipleAuthorities() {
+        List<GrantedAuthority> authorities = Arrays.asList(
+                new SimpleGrantedAuthority("ROLE_USER"),
+                new SimpleGrantedAuthority("ROLE_ADMIN"),
+                new SimpleGrantedAuthority("ROLE_MODERATOR")
+        );
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        assertEquals(3, userDetails.getAuthorities().size());
+    }
+
+    @Test
+    void testConstructorWithEmptyAuthoritiesList() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        assertNotNull(userDetails.getAuthorities());
+        assertTrue(userDetails.getAuthorities().isEmpty());
+    }
+
+    @Test
+    void testGetAuthoritiesReturnsSameContentAsProvided() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        Collection<? extends GrantedAuthority> returnedAuthorities = userDetails.getAuthorities();
+
+        assertTrue(returnedAuthorities.stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_USER")));
+        assertTrue(returnedAuthorities.stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN")));
+    }
+
+    @Test
+    void testMultipleCallsToGetAuthoritiesReturnConsistentResults() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        Collection<? extends GrantedAuthority> first = userDetails.getAuthorities();
+        Collection<? extends GrantedAuthority> second = userDetails.getAuthorities();
+
+        assertEquals(first.size(), second.size());
+    }
+
+    @Test
+    void testConstructorWithNullUsername() {
+        JwtUserDetails userDetails = new JwtUserDetails(null, null);
+
+        assertNull(userDetails.getUsername());
+    }
+
+    @Test
+    void testEI_EXPOSE_REP_InternalListNotExposedDirectly() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        // Verify the returned collection is not the same reference as the internal list
+        // by checking it's unmodifiable (defensive copy + unmodifiable wrapper)
+        Collection<? extends GrantedAuthority> returned = userDetails.getAuthorities();
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            ((Collection<GrantedAuthority>) returned).add(new SimpleGrantedAuthority("ROLE_HACKER"));
+        });
+
+        // Original internal state should remain unchanged
+        assertEquals(1, userDetails.getAuthorities().size());
+    }
+}


### PR DESCRIPTION
## Claude Agent SDK remediation PR

This PR was generated with `remediation_mode=claude_agent`.

### Validation gates
- File-scoped findings provided as input
- Effective git diff required before acceptance
- Unit test generation attempted for changed files

### Files changed
- `autocare/user-auth-service/src/main/java/com/autocare/auth/models/User.java`
- `autocare/user-auth-service/src/main/java/com/autocare/auth/payload/response/JwtResponse.java`
- `autocare/user-auth-service/src/main/java/com/autocare/auth/security/services/UserDetailsImpl.java`
- `autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/LaborLine.java`
- `autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/PartLine.java`
- `autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/ServiceSchedule.java`
- `autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/WorkOrder.java`
- `autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/security/services/JwtUserDetails.java`
- `autocare/user-auth-service/src/test/java/com/autocare/auth/models/UserTest.java`
- `autocare/user-auth-service/src/test/java/com/autocare/auth/payload/response/JwtResponseTest.java`
- `autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/LaborLineTest.java`
- `autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/PartLineTest.java`
- `autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/ServiceScheduleTest.java`
- `autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/security/services/JwtUserDetailsTest.java`

### Notes
- Please run full project tests before merging.