### PR TITLE
fix: Claude Agent SDK remediation for analyzer findings

### DIFF
--- a/autocare/user-auth-service/pom.xml
+++ b/autocare/user-auth-service/pom.xml
@@ -91,24 +91,23 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- DEMO_ONLY: Intentionally vulnerable dependencies for Code Intelligence demo. -->
-        <!-- DEMO_ONLY: log4j-core 2.14.1 -> CVE-2021-44228 (Log4Shell, RCE). Remove after demo. -->
+        <!-- log4j-core: bumped from 2.14.1 to 2.17.2 to fix CVE-2021-44228/45046/45105 (GHSA-jfh8-c2jp-5v3q, GHSA-7rjr-3q55-vv33, GHSA-p6xc-xr62-6r2g) -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.17.2</version>
         </dependency>
-        <!-- DEMO_ONLY: commons-text 1.9 -> CVE-2022-42889 (Text4Shell, RCE). Remove after demo. -->
+        <!-- commons-text: bumped from 1.9 to 1.10.0 to fix CVE-2022-42889 (GHSA-599f-7c49-w659, Text4Shell) -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
+            <version>1.10.0</version>
         </dependency>
-        <!-- DEMO_ONLY: snakeyaml 1.29 -> CVE-2022-1471 (unsafe deserialization). Remove after demo. -->
+        <!-- snakeyaml: bumped from 1.29 to 2.0 to fix CVE-2022-1471 and related (GHSA-mjmj-j48q-9wg2, GHSA-3mc7-4q67-w48m, GHSA-9w3m-gqgf-c4p9) -->
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.29</version>
+            <version>2.0</version>
         </dependency>
     </dependencies>
 

--- a/autocare/vehicle-maintenance-service/pom.xml
+++ b/autocare/vehicle-maintenance-service/pom.xml
@@ -102,17 +102,17 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- DEMO_ONLY: vulnerable commons-text for OSS scanner (CVE-2022-42889 Text4Shell). Not imported by app code. Remove after demo. -->
+        <!-- commons-text: bumped from 1.9 to 1.10.0 to fix CVE-2022-42889 (GHSA-599f-7c49-w659, Text4Shell) -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
+            <version>1.10.0</version>
         </dependency>
-        <!-- DEMO_ONLY: log4j-core 2.14.1 → CVE-2021-44228 (Log4Shell, CVSS ~10 → critical in platform OSS mapping). Not used by logging stack at runtime if logback wins; still scanned. Remove after demo. -->
+        <!-- log4j-core: bumped from 2.14.1 to 2.17.2 to fix CVE-2021-44228/45046/45105 (GHSA-jfh8-c2jp-5v3q, GHSA-7rjr-3q55-vv33, GHSA-p6xc-xr62-6r2g) -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.14.1</version>
+            <version>2.17.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Claude Agent SDK remediation PR

This PR was generated with `remediation_mode=claude_agent`.

### Validation gates
- ✅ File-scoped findings provided as input
- ✅ Effective git diff required before acceptance
- ✅ passed Post-fix build verification (`mvn compile -DskipTests`)
- ✅ Unit test generation attempted for changed files

### Files changed
- `autocare/user-auth-service/pom.xml`
- `autocare/vehicle-maintenance-service/pom.xml`

### Notes
- Run full integration tests before merging.