### PR TITLE
fix: Claude Agent SDK remediation for analyzer findings

### DIFF
--- a/autocare/user-auth-service/src/main/java/com/autocare/auth/models/User.java
+++ b/autocare/user-auth-service/src/main/java/com/autocare/auth/models/User.java
@@ -1,5 +1,6 @@
 package com.autocare.auth.models;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -60,6 +61,6 @@ public class User {
     public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }
 
-    public Set<Role> getRoles() { return roles; }
-    public void setRoles(Set<Role> roles) { this.roles = roles; }
+    public Set<Role> getRoles() { return Collections.unmodifiableSet(this.roles); }
+    public void setRoles(Set<Role> roles) { this.roles = new HashSet<>(roles); }
 }

--- a/autocare/user-auth-service/src/main/java/com/autocare/auth/payload/response/JwtResponse.java
+++ b/autocare/user-auth-service/src/main/java/com/autocare/auth/payload/response/JwtResponse.java
@@ -18,7 +18,7 @@ public class JwtResponse {
         this.id = id;
         this.username = username;
         this.email = email;
-        this.roles = roles;
+        this.roles = roles == null ? null : new ArrayList<>(roles);
     }
 
     public String getAccessToken() { return token; }

--- a/autocare/user-auth-service/src/main/java/com/autocare/auth/security/services/UserDetailsImpl.java
+++ b/autocare/user-auth-service/src/main/java/com/autocare/auth/security/services/UserDetailsImpl.java
@@ -1,6 +1,8 @@
 package com.autocare.auth.security.services;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -31,7 +33,7 @@ public class UserDetailsImpl implements UserDetails {
         this.username = username;
         this.email = email;
         this.password = password;
-        this.authorities = authorities;
+        this.authorities = authorities == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(authorities));
     }
 
     public static UserDetailsImpl build(User user) {
@@ -48,7 +50,7 @@ public class UserDetailsImpl implements UserDetails {
     }
 
     @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
+    public Collection<? extends GrantedAuthority> getAuthorities() { return Collections.unmodifiableCollection(authorities); }
 
     public Long getId() { return id; }
     public String getEmail() { return email; }

--- a/autocare/user-auth-service/src/test/java/com/autocare/auth/models/UserTest.java
+++ b/autocare/user-auth-service/src/test/java/com/autocare/auth/models/UserTest.java
@@ -1,0 +1,200 @@
+package com.autocare.auth.models;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UserTest {
+
+    private User user;
+
+    @BeforeEach
+    public void setUp() {
+        user = new User("testuser", "test@example.com", "password123");
+    }
+
+    @Test
+    public void testDefaultConstructor() {
+        User emptyUser = new User();
+        assertNull(emptyUser.getId());
+        assertNull(emptyUser.getUsername());
+        assertNull(emptyUser.getEmail());
+        assertNull(emptyUser.getPassword());
+        assertNotNull(emptyUser.getRoles());
+        assertTrue(emptyUser.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testParameterizedConstructor() {
+        assertEquals("testuser", user.getUsername());
+        assertEquals("test@example.com", user.getEmail());
+        assertEquals("password123", user.getPassword());
+        assertNull(user.getId());
+        assertNotNull(user.getRoles());
+        assertTrue(user.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testSetAndGetId() {
+        user.setId(42L);
+        assertEquals(42L, user.getId());
+    }
+
+    @Test
+    public void testSetAndGetUsername() {
+        user.setUsername("newuser");
+        assertEquals("newuser", user.getUsername());
+    }
+
+    @Test
+    public void testSetAndGetEmail() {
+        user.setEmail("new@example.com");
+        assertEquals("new@example.com", user.getEmail());
+    }
+
+    @Test
+    public void testSetAndGetPassword() {
+        user.setPassword("newpassword");
+        assertEquals("newpassword", user.getPassword());
+    }
+
+    // EI_EXPOSE_REP: getRoles() should return an unmodifiable set
+    @Test
+    public void testGetRolesReturnsUnmodifiableSet() {
+        Role role = new Role();
+        Set<Role> roles = new HashSet<>();
+        roles.add(role);
+        user.setRoles(roles);
+
+        Set<Role> returnedRoles = user.getRoles();
+        assertThrows(UnsupportedOperationException.class, () -> returnedRoles.add(new Role()));
+    }
+
+    // EI_EXPOSE_REP: getRoles() should not expose internal mutable state
+    @Test
+    public void testGetRolesDoesNotExposeInternalState() {
+        Role role1 = new Role();
+        Set<Role> roles = new HashSet<>();
+        roles.add(role1);
+        user.setRoles(roles);
+
+        Set<Role> returnedRoles = user.getRoles();
+        assertEquals(1, returnedRoles.size());
+
+        // Modifying original set should not affect internal state
+        roles.add(new Role());
+        assertEquals(1, user.getRoles().size());
+    }
+
+    // EI_EXPOSE_REP2: setRoles() should make a defensive copy
+    @Test
+    public void testSetRolesMakesDefensiveCopy() {
+        Role role1 = new Role();
+        Set<Role> roles = new HashSet<>();
+        roles.add(role1);
+        user.setRoles(roles);
+
+        // Modifying the original set after setting should not affect user's roles
+        Role role2 = new Role();
+        roles.add(role2);
+
+        assertEquals(1, user.getRoles().size());
+    }
+
+    // EI_EXPOSE_REP2: setRoles() should not store reference to passed set
+    @Test
+    public void testSetRolesDoesNotStoreExternalReference() {
+        Role role1 = new Role();
+        Set<Role> externalRoles = new HashSet<>();
+        externalRoles.add(role1);
+
+        user.setRoles(externalRoles);
+
+        // Clear the external set
+        externalRoles.clear();
+
+        // User's roles should still contain role1
+        assertEquals(1, user.getRoles().size());
+        assertTrue(user.getRoles().contains(role1));
+    }
+
+    @Test
+    public void testSetRolesWithEmptySet() {
+        user.setRoles(new HashSet<>());
+        assertNotNull(user.getRoles());
+        assertTrue(user.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testSetRolesWithMultipleRoles() {
+        Role role1 = new Role();
+        Role role2 = new Role();
+        Set<Role> roles = new HashSet<>();
+        roles.add(role1);
+        roles.add(role2);
+
+        user.setRoles(roles);
+
+        assertEquals(2, user.getRoles().size());
+        assertTrue(user.getRoles().contains(role1));
+        assertTrue(user.getRoles().contains(role2));
+    }
+
+    @Test
+    public void testGetRolesRemoveThrowsException() {
+        Role role = new Role();
+        Set<Role> roles = new HashSet<>();
+        roles.add(role);
+        user.setRoles(roles);
+
+        Set<Role> returnedRoles = user.getRoles();
+        assertThrows(UnsupportedOperationException.class, () -> returnedRoles.remove(role));
+    }
+
+    @Test
+    public void testGetRolesClearThrowsException() {
+        Role role = new Role();
+        Set<Role> roles = new HashSet<>();
+        roles.add(role);
+        user.setRoles(roles);
+
+        Set<Role> returnedRoles = user.getRoles();
+        assertThrows(UnsupportedOperationException.class, returnedRoles::clear);
+    }
+
+    @Test
+    public void testInitialRolesAreEmpty() {
+        User newUser = new User("user", "user@example.com", "pass");
+        assertNotNull(newUser.getRoles());
+        assertTrue(newUser.getRoles().isEmpty());
+    }
+
+    @Test
+    public void testInitialRolesAreUnmodifiable() {
+        User newUser = new User("user", "user@example.com", "pass");
+        Set<Role> roles = newUser.getRoles();
+        assertThrows(UnsupportedOperationException.class, () -> roles.add(new Role()));
+    }
+
+    @Test
+    public void testMultipleSetRolesCalls() {
+        Role role1 = new Role();
+        Set<Role> roles1 = new HashSet<>();
+        roles1.add(role1);
+        user.setRoles(roles1);
+        assertEquals(1, user.getRoles().size());
+
+        Role role2 = new Role();
+        Role role3 = new Role();
+        Set<Role> roles2 = new HashSet<>();
+        roles2.add(role2);
+        roles2.add(role3);
+        user.setRoles(roles2);
+        assertEquals(2, user.getRoles().size());
+        assertFalse(user.getRoles().contains(role1));
+    }
+}

--- a/autocare/user-auth-service/src/test/java/com/autocare/auth/payload/response/JwtResponseTest.java
+++ b/autocare/user-auth-service/src/test/java/com/autocare/auth/payload/response/JwtResponseTest.java
@@ -1,0 +1,176 @@
+package com.autocare.auth.payload.response;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JwtResponseTest {
+
+    @Test
+    public void testConstructorWithValidArguments() {
+        List<String> roles = Arrays.asList("ROLE_USER", "ROLE_ADMIN");
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", roles);
+
+        assertEquals("token123", response.getAccessToken());
+        assertEquals("Bearer", response.getTokenType());
+        assertEquals(1L, response.getId());
+        assertEquals("testuser", response.getUsername());
+        assertEquals("test@example.com", response.getEmail());
+        assertEquals(roles, response.getRoles());
+    }
+
+    @Test
+    public void testConstructorDefensiveCopyOfRoles() {
+        List<String> originalRoles = new ArrayList<>(Arrays.asList("ROLE_USER", "ROLE_ADMIN"));
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", originalRoles);
+
+        // Mutate the original list after construction
+        originalRoles.add("ROLE_SUPERADMIN");
+
+        // The internal roles should not be affected
+        List<String> returnedRoles = response.getRoles();
+        assertEquals(2, returnedRoles.size());
+        assertFalse(returnedRoles.contains("ROLE_SUPERADMIN"));
+    }
+
+    @Test
+    public void testGetRolesReturnsDefensiveCopy() {
+        List<String> roles = new ArrayList<>(Arrays.asList("ROLE_USER"));
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", roles);
+
+        // Mutate the returned list
+        List<String> returnedRoles = response.getRoles();
+        returnedRoles.add("ROLE_HACKER");
+
+        // The internal roles should not be affected
+        List<String> rolesAgain = response.getRoles();
+        assertEquals(1, rolesAgain.size());
+        assertFalse(rolesAgain.contains("ROLE_HACKER"));
+    }
+
+    @Test
+    public void testConstructorWithNullRoles() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+
+        assertNull(response.getRoles());
+    }
+
+    @Test
+    public void testGetRolesWithNullRolesReturnsNull() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+
+        assertNull(response.getRoles());
+    }
+
+    @Test
+    public void testGetRolesReturnsDifferentInstanceEachTime() {
+        List<String> roles = Arrays.asList("ROLE_USER");
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", roles);
+
+        List<String> firstCall = response.getRoles();
+        List<String> secondCall = response.getRoles();
+
+        assertNotSame(firstCall, secondCall);
+        assertEquals(firstCall, secondCall);
+    }
+
+    @Test
+    public void testSetAccessToken() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+        response.setAccessToken("newToken");
+
+        assertEquals("newToken", response.getAccessToken());
+    }
+
+    @Test
+    public void testSetTokenType() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+        response.setTokenType("Basic");
+
+        assertEquals("Basic", response.getTokenType());
+    }
+
+    @Test
+    public void testDefaultTokenType() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+
+        assertEquals("Bearer", response.getTokenType());
+    }
+
+    @Test
+    public void testSetId() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+        response.setId(99L);
+
+        assertEquals(99L, response.getId());
+    }
+
+    @Test
+    public void testSetEmail() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+        response.setEmail("new@example.com");
+
+        assertEquals("new@example.com", response.getEmail());
+    }
+
+    @Test
+    public void testSetUsername() {
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", null);
+        response.setUsername("newuser");
+
+        assertEquals("newuser", response.getUsername());
+    }
+
+    @Test
+    public void testConstructorWithEmptyRoles() {
+        List<String> emptyRoles = new ArrayList<>();
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", emptyRoles);
+
+        List<String> returnedRoles = response.getRoles();
+        assertNotNull(returnedRoles);
+        assertTrue(returnedRoles.isEmpty());
+    }
+
+    @Test
+    public void testConstructorWithEmptyRolesDefensiveCopy() {
+        List<String> emptyRoles = new ArrayList<>();
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", emptyRoles);
+
+        // Mutate original
+        emptyRoles.add("ROLE_USER");
+
+        // Internal should still be empty
+        List<String> returnedRoles = response.getRoles();
+        assertTrue(returnedRoles.isEmpty());
+    }
+
+    @Test
+    public void testConstructorWithNullToken() {
+        JwtResponse response = new JwtResponse(null, 1L, "testuser", "test@example.com", null);
+
+        assertNull(response.getAccessToken());
+    }
+
+    @Test
+    public void testConstructorWithNullId() {
+        JwtResponse response = new JwtResponse("token123", null, "testuser", "test@example.com", null);
+
+        assertNull(response.getId());
+    }
+
+    @Test
+    public void testRolesContentIsPreserved() {
+        List<String> roles = Arrays.asList("ROLE_USER", "ROLE_MODERATOR", "ROLE_ADMIN");
+        JwtResponse response = new JwtResponse("token123", 1L, "testuser", "test@example.com", roles);
+
+        List<String> returnedRoles = response.getRoles();
+        assertEquals(3, returnedRoles.size());
+        assertTrue(returnedRoles.contains("ROLE_USER"));
+        assertTrue(returnedRoles.contains("ROLE_MODERATOR"));
+        assertTrue(returnedRoles.contains("ROLE_ADMIN"));
+    }
+}

--- a/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/LaborLine.java
+++ b/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/LaborLine.java
@@ -29,7 +29,10 @@ public class LaborLine {
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
+    // WorkOrder is a JPA-managed entity; defensive copy would detach it and break the persistence context.
+    @SuppressWarnings("EI_EXPOSE_REP")
     public WorkOrder getWorkOrder() { return workOrder; }
+    @SuppressWarnings("EI_EXPOSE_REP2")
     public void setWorkOrder(WorkOrder workOrder) { this.workOrder = workOrder; }
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }

--- a/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/PartLine.java
+++ b/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/PartLine.java
@@ -30,7 +30,10 @@ public class PartLine {
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
+    // WorkOrder is a JPA-managed entity; defensive copy would detach it and break the persistence context.
+    @SuppressWarnings("EI_EXPOSE_REP")
     public WorkOrder getWorkOrder() { return workOrder; }
+    @SuppressWarnings("EI_EXPOSE_REP2")
     public void setWorkOrder(WorkOrder workOrder) { this.workOrder = workOrder; }
     public String getPartName() { return partName; }
     public void setPartName(String partName) { this.partName = partName; }

--- a/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/ServiceSchedule.java
+++ b/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/ServiceSchedule.java
@@ -30,9 +30,14 @@ public class ServiceSchedule {
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
+    // Vehicle and Bay are JPA-managed entities; defensive copy would detach them and break the persistence context.
+    @SuppressWarnings("EI_EXPOSE_REP")
     public Vehicle getVehicle() { return vehicle; }
+    @SuppressWarnings("EI_EXPOSE_REP2")
     public void setVehicle(Vehicle vehicle) { this.vehicle = vehicle; }
+    @SuppressWarnings("EI_EXPOSE_REP")
     public Bay getBay() { return bay; }
+    @SuppressWarnings("EI_EXPOSE_REP2")
     public void setBay(Bay bay) { this.bay = bay; }
     public LocalDateTime getScheduledAt() { return scheduledAt; }
     public void setScheduledAt(LocalDateTime scheduledAt) { this.scheduledAt = scheduledAt; }

--- a/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/WorkOrder.java
+++ b/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/WorkOrder.java
@@ -3,6 +3,7 @@ package com.autocare.maintenance.model;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -64,10 +65,10 @@ public class WorkOrder {
     public void setDescription(String description) { this.description = description; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
-    public Set<PartLine> getPartLines() { return partLines; }
+    public Set<PartLine> getPartLines() { return Collections.unmodifiableSet(partLines); }
     public void setPartLines(Set<PartLine> partLines) { this.partLines = partLines; }
-    public Set<LaborLine> getLaborLines() { return laborLines; }
+    public Set<LaborLine> getLaborLines() { return Collections.unmodifiableSet(laborLines); }
     public void setLaborLines(Set<LaborLine> laborLines) { this.laborLines = laborLines; }
-    public Set<WorkOrderStatusHistory> getStatusHistory() { return statusHistory; }
+    public Set<WorkOrderStatusHistory> getStatusHistory() { return Collections.unmodifiableSet(statusHistory); }
     public void setStatusHistory(Set<WorkOrderStatusHistory> statusHistory) { this.statusHistory = statusHistory; }
 }

--- a/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/security/services/JwtUserDetails.java
+++ b/autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/security/services/JwtUserDetails.java
@@ -3,7 +3,9 @@ package com.autocare.maintenance.security.services;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class JwtUserDetails implements UserDetails {
@@ -13,12 +15,12 @@ public class JwtUserDetails implements UserDetails {
 
     public JwtUserDetails(String username, List<GrantedAuthority> authorities) {
         this.username = username;
-        this.authorities = authorities;
+        this.authorities = new ArrayList<>(authorities);
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return authorities;
+        return Collections.unmodifiableList(authorities);
     }
 
     @Override

--- a/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/LaborLineTest.java
+++ b/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/LaborLineTest.java
@@ -1,0 +1,216 @@
+package com.autocare.maintenance.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LaborLineTest {
+
+    private LaborLine laborLine;
+
+    @BeforeEach
+    void setUp() {
+        laborLine = new LaborLine();
+    }
+
+    @Test
+    void testSetAndGetId() {
+        laborLine.setId(42L);
+        assertEquals(42L, laborLine.getId());
+    }
+
+    @Test
+    void testSetAndGetIdNull() {
+        laborLine.setId(null);
+        assertNull(laborLine.getId());
+    }
+
+    @Test
+    void testSetAndGetDescription() {
+        laborLine.setDescription("Oil Change");
+        assertEquals("Oil Change", laborLine.getDescription());
+    }
+
+    @Test
+    void testSetAndGetDescriptionNull() {
+        laborLine.setDescription(null);
+        assertNull(laborLine.getDescription());
+    }
+
+    @Test
+    void testSetAndGetHours() {
+        BigDecimal hours = new BigDecimal("2.50");
+        laborLine.setHours(hours);
+        assertEquals(new BigDecimal("2.50"), laborLine.getHours());
+    }
+
+    @Test
+    void testSetAndGetHoursNull() {
+        laborLine.setHours(null);
+        assertNull(laborLine.getHours());
+    }
+
+    @Test
+    void testSetAndGetRate() {
+        BigDecimal rate = new BigDecimal("75.00");
+        laborLine.setRate(rate);
+        assertEquals(new BigDecimal("75.00"), laborLine.getRate());
+    }
+
+    @Test
+    void testSetAndGetRateNull() {
+        laborLine.setRate(null);
+        assertNull(laborLine.getRate());
+    }
+
+    @Test
+    void testSetAndGetWorkOrder() {
+        WorkOrder workOrder = new WorkOrder();
+        laborLine.setWorkOrder(workOrder);
+        assertSame(workOrder, laborLine.getWorkOrder());
+    }
+
+    @Test
+    void testSetWorkOrderNull() {
+        laborLine.setWorkOrder(null);
+        assertNull(laborLine.getWorkOrder());
+    }
+
+    @Test
+    void testGetWorkOrderReturnsSameInstance() {
+        WorkOrder workOrder = new WorkOrder();
+        laborLine.setWorkOrder(workOrder);
+        WorkOrder retrieved = laborLine.getWorkOrder();
+        // Verify that the same JPA-managed instance is returned (not a defensive copy)
+        assertSame(workOrder, retrieved);
+    }
+
+    @Test
+    void testSetWorkOrderStoresSameInstance() {
+        WorkOrder workOrder = new WorkOrder();
+        laborLine.setWorkOrder(workOrder);
+        // Verify that the stored reference is the same object (not a copy)
+        assertSame(workOrder, laborLine.getWorkOrder());
+    }
+
+    @Test
+    void testWorkOrderMutationReflectedInLaborLine() {
+        WorkOrder workOrder = new WorkOrder();
+        laborLine.setWorkOrder(workOrder);
+        // Since we store the reference directly (no defensive copy), mutations to the
+        // original object should be reflected when retrieved
+        WorkOrder retrieved = laborLine.getWorkOrder();
+        assertSame(workOrder, retrieved);
+    }
+
+    @Test
+    void testHoursWithMinimumValidValue() {
+        BigDecimal minHours = new BigDecimal("0.01");
+        laborLine.setHours(minHours);
+        assertEquals(new BigDecimal("0.01"), laborLine.getHours());
+    }
+
+    @Test
+    void testRateWithMinimumValidValue() {
+        BigDecimal minRate = new BigDecimal("0.01");
+        laborLine.setRate(minRate);
+        assertEquals(new BigDecimal("0.01"), laborLine.getRate());
+    }
+
+    @Test
+    void testHoursWithLargeValue() {
+        BigDecimal largeHours = new BigDecimal("9999.99");
+        laborLine.setHours(largeHours);
+        assertEquals(new BigDecimal("9999.99"), laborLine.getHours());
+    }
+
+    @Test
+    void testRateWithLargeValue() {
+        BigDecimal largeRate = new BigDecimal("99999999.99");
+        laborLine.setRate(largeRate);
+        assertEquals(new BigDecimal("99999999.99"), laborLine.getRate());
+    }
+
+    @Test
+    void testDefaultIdIsNull() {
+        assertNull(laborLine.getId());
+    }
+
+    @Test
+    void testDefaultWorkOrderIsNull() {
+        assertNull(laborLine.getWorkOrder());
+    }
+
+    @Test
+    void testDefaultDescriptionIsNull() {
+        assertNull(laborLine.getDescription());
+    }
+
+    @Test
+    void testDefaultHoursIsNull() {
+        assertNull(laborLine.getHours());
+    }
+
+    @Test
+    void testDefaultRateIsNull() {
+        assertNull(laborLine.getRate());
+    }
+
+    @Test
+    void testSetWorkOrderMultipleTimes() {
+        WorkOrder firstWorkOrder = new WorkOrder();
+        WorkOrder secondWorkOrder = new WorkOrder();
+
+        laborLine.setWorkOrder(firstWorkOrder);
+        assertSame(firstWorkOrder, laborLine.getWorkOrder());
+
+        laborLine.setWorkOrder(secondWorkOrder);
+        assertSame(secondWorkOrder, laborLine.getWorkOrder());
+    }
+
+    @Test
+    void testHoursImmutabilityNotEnforced() {
+        // BigDecimal is immutable by nature, so this verifies the value is stored correctly
+        BigDecimal hours = new BigDecimal("3.00");
+        laborLine.setHours(hours);
+        BigDecimal retrieved = laborLine.getHours();
+        assertEquals(hours, retrieved);
+    }
+
+    @Test
+    void testRateImmutabilityNotEnforced() {
+        // BigDecimal is immutable by nature, so this verifies the value is stored correctly
+        BigDecimal rate = new BigDecimal("100.00");
+        laborLine.setRate(rate);
+        BigDecimal retrieved = laborLine.getRate();
+        assertEquals(rate, retrieved);
+    }
+
+    @Test
+    void testDescriptionWithSpecialCharacters() {
+        String description = "Brake pad replacement - front axle (2 pads)";
+        laborLine.setDescription(description);
+        assertEquals(description, laborLine.getDescription());
+    }
+
+    @Test
+    void testDescriptionWithEmptyString() {
+        laborLine.setDescription("");
+        assertEquals("", laborLine.getDescription());
+    }
+
+    @Test
+    void testIdWithZero() {
+        laborLine.setId(0L);
+        assertEquals(0L, laborLine.getId());
+    }
+
+    @Test
+    void testIdWithNegativeValue() {
+        laborLine.setId(-1L);
+        assertEquals(-1L, laborLine.getId());
+    }
+}

--- a/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/PartLineTest.java
+++ b/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/PartLineTest.java
@@ -1,0 +1,186 @@
+package com.autocare.maintenance.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PartLineTest {
+
+    private PartLine partLine;
+
+    @BeforeEach
+    void setUp() {
+        partLine = new PartLine();
+    }
+
+    @Test
+    void testSetAndGetId() {
+        partLine.setId(42L);
+        assertEquals(42L, partLine.getId());
+    }
+
+    @Test
+    void testSetAndGetPartName() {
+        partLine.setPartName("Oil Filter");
+        assertEquals("Oil Filter", partLine.getPartName());
+    }
+
+    @Test
+    void testSetAndGetQuantity() {
+        partLine.setQuantity(5);
+        assertEquals(5, partLine.getQuantity());
+    }
+
+    @Test
+    void testSetAndGetUnitCost() {
+        BigDecimal cost = new BigDecimal("19.99");
+        partLine.setUnitCost(cost);
+        assertEquals(new BigDecimal("19.99"), partLine.getUnitCost());
+    }
+
+    @Test
+    void testSetAndGetWorkOrder() {
+        WorkOrder workOrder = new WorkOrder();
+        partLine.setWorkOrder(workOrder);
+        assertSame(workOrder, partLine.getWorkOrder());
+    }
+
+    @Test
+    void testGetWorkOrderReturnsSameReference() {
+        WorkOrder workOrder = new WorkOrder();
+        partLine.setWorkOrder(workOrder);
+        WorkOrder retrieved = partLine.getWorkOrder();
+        // Verify that the same JPA-managed entity reference is returned (not a defensive copy)
+        assertSame(workOrder, retrieved);
+    }
+
+    @Test
+    void testSetWorkOrderStoresSameReference() {
+        WorkOrder workOrder = new WorkOrder();
+        partLine.setWorkOrder(workOrder);
+        // Verify that the stored reference is the same object passed in (not a copy)
+        assertSame(workOrder, partLine.getWorkOrder());
+    }
+
+    @Test
+    void testWorkOrderMutationReflectedInPartLine() {
+        WorkOrder workOrder = new WorkOrder();
+        partLine.setWorkOrder(workOrder);
+        // Since we store the reference directly (no defensive copy), mutations to the
+        // original object should be reflected when retrieved
+        WorkOrder retrieved = partLine.getWorkOrder();
+        assertSame(workOrder, retrieved);
+    }
+
+    @Test
+    void testSetWorkOrderToNull() {
+        partLine.setWorkOrder(null);
+        assertNull(partLine.getWorkOrder());
+    }
+
+    @Test
+    void testSetIdToNull() {
+        partLine.setId(null);
+        assertNull(partLine.getId());
+    }
+
+    @Test
+    void testSetPartNameToNull() {
+        partLine.setPartName(null);
+        assertNull(partLine.getPartName());
+    }
+
+    @Test
+    void testSetQuantityToNull() {
+        partLine.setQuantity(null);
+        assertNull(partLine.getQuantity());
+    }
+
+    @Test
+    void testSetUnitCostToNull() {
+        partLine.setUnitCost(null);
+        assertNull(partLine.getUnitCost());
+    }
+
+    @Test
+    void testDefaultIdIsNull() {
+        assertNull(partLine.getId());
+    }
+
+    @Test
+    void testDefaultWorkOrderIsNull() {
+        assertNull(partLine.getWorkOrder());
+    }
+
+    @Test
+    void testDefaultPartNameIsNull() {
+        assertNull(partLine.getPartName());
+    }
+
+    @Test
+    void testDefaultQuantityIsNull() {
+        assertNull(partLine.getQuantity());
+    }
+
+    @Test
+    void testDefaultUnitCostIsNull() {
+        assertNull(partLine.getUnitCost());
+    }
+
+    @Test
+    void testUnitCostPrecision() {
+        BigDecimal cost = new BigDecimal("0.01");
+        partLine.setUnitCost(cost);
+        assertEquals(new BigDecimal("0.01"), partLine.getUnitCost());
+    }
+
+    @Test
+    void testQuantityMinimumValue() {
+        partLine.setQuantity(1);
+        assertEquals(1, partLine.getQuantity());
+    }
+
+    @Test
+    void testPartLineWithAllFieldsSet() {
+        WorkOrder workOrder = new WorkOrder();
+        partLine.setId(1L);
+        partLine.setWorkOrder(workOrder);
+        partLine.setPartName("Brake Pad");
+        partLine.setQuantity(4);
+        partLine.setUnitCost(new BigDecimal("25.50"));
+
+        assertEquals(1L, partLine.getId());
+        assertSame(workOrder, partLine.getWorkOrder());
+        assertEquals("Brake Pad", partLine.getPartName());
+        assertEquals(4, partLine.getQuantity());
+        assertEquals(new BigDecimal("25.50"), partLine.getUnitCost());
+    }
+
+    @Test
+    void testReplaceWorkOrder() {
+        WorkOrder workOrder1 = new WorkOrder();
+        WorkOrder workOrder2 = new WorkOrder();
+
+        partLine.setWorkOrder(workOrder1);
+        assertSame(workOrder1, partLine.getWorkOrder());
+
+        partLine.setWorkOrder(workOrder2);
+        assertSame(workOrder2, partLine.getWorkOrder());
+    }
+
+    @Test
+    void testUnitCostLargeValue() {
+        BigDecimal largeCost = new BigDecimal("99999999.99");
+        partLine.setUnitCost(largeCost);
+        assertEquals(new BigDecimal("99999999.99"), partLine.getUnitCost());
+    }
+
+    @Test
+    void testQuantityLargeValue() {
+        partLine.setQuantity(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, partLine.getQuantity());
+    }
+}

--- a/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/ServiceScheduleTest.java
+++ b/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/ServiceScheduleTest.java
@@ -1,0 +1,216 @@
+package com.autocare.maintenance.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ServiceScheduleTest {
+
+    private ServiceSchedule serviceSchedule;
+
+    @BeforeEach
+    void setUp() {
+        serviceSchedule = new ServiceSchedule();
+    }
+
+    @Test
+    void testDefaultStatusIsConfirmed() {
+        assertEquals("CONFIRMED", serviceSchedule.getStatus());
+    }
+
+    @Test
+    void testSetAndGetId() {
+        serviceSchedule.setId(42L);
+        assertEquals(42L, serviceSchedule.getId());
+    }
+
+    @Test
+    void testSetAndGetIdNull() {
+        serviceSchedule.setId(null);
+        assertNull(serviceSchedule.getId());
+    }
+
+    @Test
+    void testSetAndGetVehicle() {
+        Vehicle vehicle = new Vehicle();
+        serviceSchedule.setVehicle(vehicle);
+        assertSame(vehicle, serviceSchedule.getVehicle());
+    }
+
+    @Test
+    void testSetVehicleNull() {
+        serviceSchedule.setVehicle(null);
+        assertNull(serviceSchedule.getVehicle());
+    }
+
+    @Test
+    void testGetVehicleReturnsSameReference() {
+        Vehicle vehicle = new Vehicle();
+        serviceSchedule.setVehicle(vehicle);
+        Vehicle retrieved = serviceSchedule.getVehicle();
+        assertSame(vehicle, retrieved,
+                "getVehicle() should return the same JPA-managed entity reference (no defensive copy)");
+    }
+
+    @Test
+    void testSetVehicleStoresSameReference() {
+        Vehicle vehicle = new Vehicle();
+        serviceSchedule.setVehicle(vehicle);
+        assertSame(vehicle, serviceSchedule.getVehicle(),
+                "setVehicle() should store the same JPA-managed entity reference (no defensive copy)");
+    }
+
+    @Test
+    void testSetAndGetBay() {
+        Bay bay = new Bay();
+        serviceSchedule.setBay(bay);
+        assertSame(bay, serviceSchedule.getBay());
+    }
+
+    @Test
+    void testSetBayNull() {
+        serviceSchedule.setBay(null);
+        assertNull(serviceSchedule.getBay());
+    }
+
+    @Test
+    void testGetBayReturnsSameReference() {
+        Bay bay = new Bay();
+        serviceSchedule.setBay(bay);
+        Bay retrieved = serviceSchedule.getBay();
+        assertSame(bay, retrieved,
+                "getBay() should return the same JPA-managed entity reference (no defensive copy)");
+    }
+
+    @Test
+    void testSetBayStoresSameReference() {
+        Bay bay = new Bay();
+        serviceSchedule.setBay(bay);
+        assertSame(bay, serviceSchedule.getBay(),
+                "setBay() should store the same JPA-managed entity reference (no defensive copy)");
+    }
+
+    @Test
+    void testSetAndGetScheduledAt() {
+        LocalDateTime now = LocalDateTime.now();
+        serviceSchedule.setScheduledAt(now);
+        assertEquals(now, serviceSchedule.getScheduledAt());
+    }
+
+    @Test
+    void testSetScheduledAtNull() {
+        serviceSchedule.setScheduledAt(null);
+        assertNull(serviceSchedule.getScheduledAt());
+    }
+
+    @Test
+    void testSetAndGetServiceType() {
+        serviceSchedule.setServiceType("OIL_CHANGE");
+        assertEquals("OIL_CHANGE", serviceSchedule.getServiceType());
+    }
+
+    @Test
+    void testSetServiceTypeNull() {
+        serviceSchedule.setServiceType(null);
+        assertNull(serviceSchedule.getServiceType());
+    }
+
+    @Test
+    void testSetAndGetStatus() {
+        serviceSchedule.setStatus("PENDING");
+        assertEquals("PENDING", serviceSchedule.getStatus());
+    }
+
+    @Test
+    void testSetStatusNull() {
+        serviceSchedule.setStatus(null);
+        assertNull(serviceSchedule.getStatus());
+    }
+
+    @Test
+    void testSetStatusOverridesDefault() {
+        assertEquals("CONFIRMED", serviceSchedule.getStatus());
+        serviceSchedule.setStatus("CANCELLED");
+        assertEquals("CANCELLED", serviceSchedule.getStatus());
+    }
+
+    @Test
+    void testVehicleReferenceIsNotCopied_mutationReflected() {
+        Vehicle vehicle = new Vehicle();
+        serviceSchedule.setVehicle(vehicle);
+        // Since no defensive copy is made, the same reference is stored
+        // Mutating the original vehicle should be reflected in the retrieved vehicle
+        Vehicle retrieved = serviceSchedule.getVehicle();
+        assertSame(vehicle, retrieved,
+                "JPA entity should not be defensively copied; mutation should be reflected");
+    }
+
+    @Test
+    void testBayReferenceIsNotCopied_mutationReflected() {
+        Bay bay = new Bay();
+        serviceSchedule.setBay(bay);
+        // Since no defensive copy is made, the same reference is stored
+        Bay retrieved = serviceSchedule.getBay();
+        assertSame(bay, retrieved,
+                "JPA entity should not be defensively copied; mutation should be reflected");
+    }
+
+    @Test
+    void testNewServiceScheduleHasNullId() {
+        assertNull(serviceSchedule.getId());
+    }
+
+    @Test
+    void testNewServiceScheduleHasNullVehicle() {
+        assertNull(serviceSchedule.getVehicle());
+    }
+
+    @Test
+    void testNewServiceScheduleHasNullBay() {
+        assertNull(serviceSchedule.getBay());
+    }
+
+    @Test
+    void testNewServiceScheduleHasNullScheduledAt() {
+        assertNull(serviceSchedule.getScheduledAt());
+    }
+
+    @Test
+    void testNewServiceScheduleHasNullServiceType() {
+        assertNull(serviceSchedule.getServiceType());
+    }
+
+    @Test
+    void testScheduledAtWithSpecificDateTime() {
+        LocalDateTime specificTime = LocalDateTime.of(2024, 6, 15, 10, 30, 0);
+        serviceSchedule.setScheduledAt(specificTime);
+        assertEquals(LocalDateTime.of(2024, 6, 15, 10, 30, 0), serviceSchedule.getScheduledAt());
+    }
+
+    @Test
+    void testMultipleVehicleAssignments() {
+        Vehicle vehicle1 = new Vehicle();
+        Vehicle vehicle2 = new Vehicle();
+
+        serviceSchedule.setVehicle(vehicle1);
+        assertSame(vehicle1, serviceSchedule.getVehicle());
+
+        serviceSchedule.setVehicle(vehicle2);
+        assertSame(vehicle2, serviceSchedule.getVehicle());
+    }
+
+    @Test
+    void testMultipleBayAssignments() {
+        Bay bay1 = new Bay();
+        Bay bay2 = new Bay();
+
+        serviceSchedule.setBay(bay1);
+        assertSame(bay1, serviceSchedule.getBay());
+
+        serviceSchedule.setBay(bay2);
+        assertSame(bay2, serviceSchedule.getBay());
+    }
+}

--- a/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/security/services/JwtUserDetailsTest.java
+++ b/autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/security/services/JwtUserDetailsTest.java
@@ -1,0 +1,200 @@
+package com.autocare.maintenance.security.services;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JwtUserDetailsTest {
+
+    @Test
+    void testConstructorAndGetUsername() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        assertEquals("testuser", userDetails.getUsername());
+    }
+
+    @Test
+    void testGetAuthoritiesReturnsCorrectAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        Collection<? extends GrantedAuthority> result = userDetails.getAuthorities();
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.stream().anyMatch(a -> a.getAuthority().equals("ROLE_USER")));
+        assertTrue(result.stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN")));
+    }
+
+    @Test
+    void testGetAuthoritiesReturnsUnmodifiableList() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        Collection<? extends GrantedAuthority> result = userDetails.getAuthorities();
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            result.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        });
+    }
+
+    @Test
+    void testModifyingOriginalListDoesNotAffectInternalState() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        // Modify the original list after construction
+        authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        authorities.clear();
+
+        // Internal state should not be affected
+        Collection<? extends GrantedAuthority> result = userDetails.getAuthorities();
+        assertEquals(1, result.size());
+        assertTrue(result.stream().anyMatch(a -> a.getAuthority().equals("ROLE_USER")));
+    }
+
+    @Test
+    void testGetAuthoritiesReturnsCopyNotSameReference() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        Collection<? extends GrantedAuthority> result1 = userDetails.getAuthorities();
+        Collection<? extends GrantedAuthority> result2 = userDetails.getAuthorities();
+
+        // Both calls should return collections with same content
+        assertEquals(result1.size(), result2.size());
+    }
+
+    @Test
+    void testGetPasswordReturnsNull() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", new ArrayList<>());
+
+        assertNull(userDetails.getPassword());
+    }
+
+    @Test
+    void testIsAccountNonExpiredReturnsTrue() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", new ArrayList<>());
+
+        assertTrue(userDetails.isAccountNonExpired());
+    }
+
+    @Test
+    void testIsAccountNonLockedReturnsTrue() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", new ArrayList<>());
+
+        assertTrue(userDetails.isAccountNonLocked());
+    }
+
+    @Test
+    void testIsCredentialsNonExpiredReturnsTrue() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", new ArrayList<>());
+
+        assertTrue(userDetails.isCredentialsNonExpired());
+    }
+
+    @Test
+    void testIsEnabledReturnsTrue() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", new ArrayList<>());
+
+        assertTrue(userDetails.isEnabled());
+    }
+
+    @Test
+    void testConstructorWithEmptyAuthorities() {
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", new ArrayList<>());
+
+        assertNotNull(userDetails.getAuthorities());
+        assertTrue(userDetails.getAuthorities().isEmpty());
+    }
+
+    @Test
+    void testConstructorWithNullUsername() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        JwtUserDetails userDetails = new JwtUserDetails(null, authorities);
+
+        assertNull(userDetails.getUsername());
+    }
+
+    @Test
+    void testGetAuthoritiesDoesNotExposeInternalRepresentation() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        Collection<? extends GrantedAuthority> result = userDetails.getAuthorities();
+
+        // Attempting to cast and modify should not affect internal state
+        assertThrows(UnsupportedOperationException.class, () -> {
+            ((List<GrantedAuthority>) result).add(new SimpleGrantedAuthority("ROLE_HACKER"));
+        });
+
+        // Internal state should remain unchanged
+        assertEquals(1, userDetails.getAuthorities().size());
+    }
+
+    @Test
+    void testConstructorDefensivelyCopiesAuthorities() {
+        List<GrantedAuthority> originalAuthorities = new ArrayList<>();
+        originalAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", originalAuthorities);
+
+        // Verify initial state
+        assertEquals(1, userDetails.getAuthorities().size());
+
+        // Mutate original list
+        originalAuthorities.add(new SimpleGrantedAuthority("ROLE_INJECTED"));
+
+        // Internal state should not change
+        assertEquals(1, userDetails.getAuthorities().size());
+    }
+
+    @Test
+    void testWithMultipleAuthorities() {
+        List<GrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority("ROLE_USER"),
+                new SimpleGrantedAuthority("ROLE_ADMIN"),
+                new SimpleGrantedAuthority("ROLE_MODERATOR")
+        );
+
+        JwtUserDetails userDetails = new JwtUserDetails("admin", authorities);
+
+        assertEquals("admin", userDetails.getUsername());
+        assertEquals(3, userDetails.getAuthorities().size());
+    }
+
+    @Test
+    void testGetAuthoritiesRemoveThrowsException() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        JwtUserDetails userDetails = new JwtUserDetails("testuser", authorities);
+
+        Collection<? extends GrantedAuthority> result = userDetails.getAuthorities();
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            result.remove(new SimpleGrantedAuthority("ROLE_USER"));
+        });
+    }
+}


### PR DESCRIPTION
## Claude Agent SDK remediation PR

This PR was generated with `remediation_mode=claude_agent`.

### Validation gates
- File-scoped findings provided as input
- Effective git diff required before acceptance
- Unit test generation attempted for changed files

### Files changed
- `autocare/user-auth-service/src/main/java/com/autocare/auth/models/User.java`
- `autocare/user-auth-service/src/main/java/com/autocare/auth/payload/response/JwtResponse.java`
- `autocare/user-auth-service/src/main/java/com/autocare/auth/security/services/UserDetailsImpl.java`
- `autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/LaborLine.java`
- `autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/PartLine.java`
- `autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/ServiceSchedule.java`
- `autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/model/WorkOrder.java`
- `autocare/vehicle-maintenance-service/src/main/java/com/autocare/maintenance/security/services/JwtUserDetails.java`
- `autocare/user-auth-service/src/test/java/com/autocare/auth/models/UserTest.java`
- `autocare/user-auth-service/src/test/java/com/autocare/auth/payload/response/JwtResponseTest.java`
- `autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/LaborLineTest.java`
- `autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/PartLineTest.java`
- `autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/model/ServiceScheduleTest.java`
- `autocare/vehicle-maintenance-service/src/test/java/com/autocare/maintenance/security/services/JwtUserDetailsTest.java`

### Notes
- Please run full project tests before merging.